### PR TITLE
docs: repair README links and add DeltaAI venv guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Full documentation at **[livn-org.github.io/livn](https://livn-org.github.io/liv
 
 - [Getting started](https://livn-org.github.io/livn/guide/getting-started) — installation, first simulation, using datasets
 - [Concepts](https://livn-org.github.io/livn/guide/concepts/env) — environments, systems, models, IO, encoding, decoding, stimulus
-- [Systems](https://livn-org.github.io/livn/guide/systems/) — generating, tuning, and sampling custom systems
-- [Examples](https://livn-org.github.io/livn/examples/dataset) — dataset usage, differentiable simulation, reinforcement learning
+- [Systems](https://livn-org.github.io/livn/systems/) — generating, tuning, and sampling custom systems
+- [Examples](https://livn-org.github.io/livn/examples) — dataset usage, differentiable simulation, reinforcement learning
 
 ### Full installation
 

--- a/docs/installation/ncsa-deltaai.md
+++ b/docs/installation/ncsa-deltaai.md
@@ -16,4 +16,4 @@ export MPICC="cc -shared"
 export UV_PYTHON=/opt/cray/pe/python/3.11.7/bin/python
 ```
 
-Once configured, follow the [standard instructions](../installation/).
+With this environment, use `uv` as normal to create a venv (e.g. on `/work/hdd/<partition>/$USER/livn`). For more details, see the [standard instructions](../installation/).


### PR DESCRIPTION
Document the Cray-specific module loads, env vars, and the venv-targeted mpi4py rebuild required to install livn on NCSA DeltaAI.